### PR TITLE
Feature/illust metadata api

### DIFF
--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,3 +1,3 @@
-from . import test, user, record, records
+from . import test, user, record, records, illust_metadata, illust_metadata_list
 
-__all__ = ["test", "user", "record", "records"]
+__all__ = ["test", "user", "record", "records", "illust_metadata", "illust_metadata_list"]

--- a/src/api/illust_metadata.py
+++ b/src/api/illust_metadata.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 from src.crud.illust_metadata import create_illust_metadata, delete_illust_metadata, get_illust_metadata_contour, get_illust_metadata_badge_image, update_illust_metadata
 from src.model.db_core import get_session
-from src.schema.illust_metadata import IllustMetadataCreate, IllustMetadataResponse
+from src.schema.illust_metadata import IllustMetadataCreate, IllustMetadataResponse, IllustMetadataContourResponse, IllustMetadataBadgeImageResponse, IllustMetadataUpdate
 
 router = APIRouter()
 
@@ -28,7 +28,7 @@ def create_dataset(
     "/contour/{illust_metadata_id}",
     operation_id="read_illust_metadata_contour",
     summary="Read IllustMetadata Contour Points",
-    response_model=IllustMetadataResponse,
+    response_model=IllustMetadataContourResponse,
     status_code=status.HTTP_200_OK,
 )
 def read_illust_metadata_contour(
@@ -42,7 +42,7 @@ def read_illust_metadata_contour(
     "/badge_image/{illust_metadata_id}",
     operation_id="read_illust_metadata_badge_image",
     summary="Read IllustMetadata Badge Image",
-    response_model=IllustMetadataResponse,
+    response_model=IllustMetadataBadgeImageResponse,
     status_code=status.HTTP_200_OK,
 )
 def read_illust_metadata_badge_image(
@@ -62,7 +62,7 @@ def read_illust_metadata_badge_image(
 )
 def update_dataset(
     illust_metadata_id: UUID,
-    illust_metadata: IllustMetadataCreate,
+    illust_metadata: IllustMetadataUpdate,
     db: Session = Depends(get_session),
 ):
     return update_illust_metadata(db=db, illust_metadata_id=illust_metadata_id, illust_metadata=illust_metadata)

--- a/src/api/illust_metadata.py
+++ b/src/api/illust_metadata.py
@@ -1,0 +1,81 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from src.crud.illust_metadata import create_illust_metadata, delete_illust_metadata, get_illust_metadata_contour, get_illust_metadata_badge_image, update_illust_metadata
+from src.model.db_core import get_session
+from src.schema.illust_metadata import IllustMetadataCreate, IllustMetadataResponse
+
+router = APIRouter()
+
+
+@router.post(
+    "",
+    operation_id="create_illust_metadata",
+    summary="Create IllustMetadata",
+    response_model=IllustMetadataResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_dataset(
+    illust_metadata: IllustMetadataCreate,
+    db: Session = Depends(get_session),
+):
+    return create_illust_metadata(db=db, illust_metadata=illust_metadata)
+
+
+@router.get(
+    "/contour/{illust_metadata_id}",
+    operation_id="read_illust_metadata_contour",
+    summary="Read IllustMetadata Contour Points",
+    response_model=IllustMetadataResponse,
+    status_code=status.HTTP_200_OK,
+)
+def read_illust_metadata_contour(
+    illust_metadata_id: UUID,
+    db: Session = Depends(get_session),
+):
+    return get_illust_metadata_contour(db=db, illust_metadata_id=illust_metadata_id)
+
+
+@router.get(
+    "/badge_image/{illust_metadata_id}",
+    operation_id="read_illust_metadata_badge_image",
+    summary="Read IllustMetadata Badge Image",
+    response_model=IllustMetadataResponse,
+    status_code=status.HTTP_200_OK,
+)
+def read_illust_metadata_badge_image(
+    illust_metadata_id: UUID,
+    db: Session = Depends(get_session),
+):
+    return get_illust_metadata_badge_image(db=db, illust_metadata_id=illust_metadata_id)
+
+
+
+@router.put(
+    "/{illust_metadata_id}",
+    operation_id="update_illust_metadata",
+    summary="Update IllustMetadata",
+    response_model=IllustMetadataResponse,
+    status_code=status.HTTP_200_OK,
+)
+def update_dataset(
+    illust_metadata_id: UUID,
+    illust_metadata: IllustMetadataCreate,
+    db: Session = Depends(get_session),
+):
+    return update_illust_metadata(db=db, illust_metadata_id=illust_metadata_id, illust_metadata=illust_metadata)
+
+
+@router.delete(
+    "/{illust_metadata_id}",
+    operation_id="delete_illust_metadata",
+    summary="Delete IllustMetadata",
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def delete_dataset(
+    illust_metadata_id: UUID,
+    db: Session = Depends(get_session),
+):
+    delete_illust_metadata(db=db, illust_metadata_id=illust_metadata_id)

--- a/src/api/illust_metadata_list.py
+++ b/src/api/illust_metadata_list.py
@@ -3,21 +3,56 @@ from typing import List
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.orm import Session
 
-from src.crud.illust_metadata_list import get_all_illust_metadata_basic_info
+from src.crud.illust_metadata_list import (
+    get_all_illust_metadata_basic_info,
+    # create_illust_metadata_list,
+    get_all_illust_metadata,
+)
 from src.model.db_core import get_session
-from src.schema.illust_metadata import IllustMetadataBase
+from src.schema.illust_metadata import (
+    IllustMetadataResponse,
+    IllustMetadataCreate,
+    IllustMetadataBasicInfoResponse,
+)
 
 router = APIRouter()
+
+
+# @router.post(
+#     "",
+#     operation_id="create_illust_metadata",
+#     summary="Create IllustMetadata",
+#     response_model=List[IllustMetadataResponse],
+#     status_code=status.HTTP_201_CREATED,
+# )
+# def create_dataset(
+#     illust_metadata_list: List[IllustMetadataCreate],
+#     db: Session = Depends(get_session),
+# ):
+#     return create_illust_metadata_list(db=db, illust_metadata_list=illust_metadata_list)
 
 
 @router.get(
     "",
     operation_id="read_illust_metadata_list_basic_info",
     summary="Read all IllustMetadata basic info",
-    response_model=List[IllustMetadataBase],
+    response_model=List[IllustMetadataBasicInfoResponse],
     status_code=status.HTTP_200_OK,
 )
 def read_dataset(
     db: Session = Depends(get_session),
 ):
     return get_all_illust_metadata_basic_info(db=db)
+
+
+@router.get(
+    "/all",
+    operation_id="read_illust_metadata",
+    summary="Read all IllustMetadata",
+    response_model=List[IllustMetadataResponse],
+    status_code=status.HTTP_200_OK,
+)
+def read_dataset(
+    db: Session = Depends(get_session),
+):
+    return get_all_illust_metadata(db=db)

--- a/src/api/illust_metadata_list.py
+++ b/src/api/illust_metadata_list.py
@@ -1,0 +1,23 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from src.crud.illust_metadata_list import get_all_illust_metadata_basic_info
+from src.model.db_core import get_session
+from src.schema.illust_metadata import IllustMetadataBase
+
+router = APIRouter()
+
+
+@router.get(
+    "",
+    operation_id="read_illust_metadata_list_basic_info",
+    summary="Read all IllustMetadata basic info",
+    response_model=List[IllustMetadataBase],
+    status_code=status.HTTP_200_OK,
+)
+def read_dataset(
+    db: Session = Depends(get_session),
+):
+    return get_all_illust_metadata_basic_info(db=db)

--- a/src/crud/illust_metadata.py
+++ b/src/crud/illust_metadata.py
@@ -33,6 +33,7 @@ def get_illust_metadata_contour(db: Session, illust_metadata_id: UUID):
             IllustMetadataTable.id,
             IllustMetadataTable.contour_points
         ).filter(IllustMetadataTable.id == illust_metadata_id ).first()
+
         if illust_metadata is None:
             raise HTTPException(status_code=404, detail=f"Item not found")
     except:
@@ -45,6 +46,7 @@ def get_illust_metadata_badge_image(db: Session, illust_metadata_id: UUID):
     try:
         illust_metadata = db.query(
             IllustMetadataTable.id,
+            IllustMetadataTable.name,
             IllustMetadataTable.badge_image
         ).filter(IllustMetadataTable.id == illust_metadata_id).first()
         if illust_metadata is None:
@@ -58,7 +60,7 @@ def update_illust_metadata(db: Session, illust_metadata_id: UUID, illust_metadat
     try:
         _illust_metadata = db.query(IllustMetadataTable).filter(IllustMetadataTable.id == illust_metadata_id).first()
         _illust_metadata.name = illust_metadata.name
-        _illust_metadata.genre = illust_metadata.genre,
+        _illust_metadata.genre = str(illust_metadata.genre),
         _illust_metadata.original_image = illust_metadata.original_image,
         _illust_metadata.badge_image = illust_metadata.badge_image,
         _illust_metadata.contour_points = illust_metadata.contour_points

--- a/src/crud/illust_metadata.py
+++ b/src/crud/illust_metadata.py
@@ -1,0 +1,80 @@
+from uuid import UUID, uuid4
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from src.model.illust_metadata import IllustMetadataTable
+from src.schema.illust_metadata import IllustMetadataCreate, IllustMetadataUpdate
+
+
+def create_illust_metadata(db: Session, illust_metadata: IllustMetadataCreate):
+    try:
+        illust_metadata = IllustMetadataTable(
+            id=uuid4(),
+            name=illust_metadata.name,
+            genre=illust_metadata.genre,
+            original_image=illust_metadata.original_image,
+            badge_image=illust_metadata.badge_image,
+            contour_points=illust_metadata.contour_points
+        )
+        db.add(illust_metadata)
+        db.commit()
+        db.refresh(illust_metadata)
+    except:
+        db.rollback()
+        raise
+    return illust_metadata
+
+
+# IDから輪郭の相対座標を取得
+def get_illust_metadata_contour(db: Session, illust_metadata_id: UUID):
+    try:
+        illust_metadata = db.query(
+            IllustMetadataTable.id,
+            IllustMetadataTable.contour_points
+        ).filter(IllustMetadataTable.id == illust_metadata_id ).first()
+        if illust_metadata is None:
+            raise HTTPException(status_code=404, detail=f"Item not found")
+    except:
+        raise
+    return illust_metadata
+
+
+# IDからバッジ画像を取得
+def get_illust_metadata_badge_image(db: Session, illust_metadata_id: UUID):
+    try:
+        illust_metadata = db.query(
+            IllustMetadataTable.id,
+            IllustMetadataTable.badge_image
+        ).filter(IllustMetadataTable.id == illust_metadata_id).first()
+        if illust_metadata is None:
+            raise HTTPException(status_code=404, detail=f"Item not found")
+    except:
+        raise
+    return illust_metadata
+    
+
+def update_illust_metadata(db: Session, illust_metadata_id: UUID, illust_metadata: IllustMetadataUpdate):
+    try:
+        _illust_metadata = db.query(IllustMetadataTable).filter(IllustMetadataTable.id == illust_metadata_id).first()
+        _illust_metadata.name = illust_metadata.name
+        _illust_metadata.genre = illust_metadata.genre,
+        _illust_metadata.original_image = illust_metadata.original_image,
+        _illust_metadata.badge_image = illust_metadata.badge_image,
+        _illust_metadata.contour_points = illust_metadata.contour_points
+        db.commit()
+    except:
+        db.rollback()
+        raise
+    return _illust_metadata
+
+
+def delete_illust_metadata(db: Session, illust_metadata_id: UUID):
+    try:
+        db.query(IllustMetadataTable).filter(IllustMetadataTable.id == illust_metadata_id).delete()
+        db.commit()
+    except:
+        db.rollback()
+        raise
+    return
+

--- a/src/crud/illust_metadata_list.py
+++ b/src/crud/illust_metadata_list.py
@@ -1,7 +1,31 @@
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
+from typing import List
+from uuid import uuid4
 
+from src.schema.illust_metadata import IllustMetadataCreate
 from src.model.illust_metadata import IllustMetadataTable
+
+
+# 複数のレコードをまとめて登録する
+# def create_illust_metadata_list(db: Session, illust_metadata_list: List[IllustMetadataCreate]):
+#     try:
+#         for illust_metadata in illust_metadata_list:
+#             illust_metadata = IllustMetadataTable(
+#                 id=uuid4(),
+#                 name=illust_metadata.name,
+#                 genre=illust_metadata.genre,
+#                 original_image=illust_metadata.original_image,
+#                 badge_image=illust_metadata.badge_image,
+#                 contour_points=illust_metadata.contour_points
+#             )
+#             db.add(illust_metadata)
+#         db.commit()
+#         db.refresh(illust_metadata)
+#     except:
+#         db.rollback()
+#         raise
+#     return illust_metadata_list
 
 
 # 全てのレコードのID,イラスト名,ジャンル,イラスト画像を取得
@@ -18,3 +42,14 @@ def get_all_illust_metadata_basic_info(db: Session):
     except:
         raise
     return illust_metadata_basic_info
+
+
+# 全てのレコードのID,イラスト名,ジャンル,イラスト画像を取得
+def get_all_illust_metadata(db: Session):
+    try:
+        illust_metadata = db.query(IllustMetadataTable).all()
+        if illust_metadata is None:
+            raise HTTPException(status_code=404, detail=f"Item not found")
+    except:
+        raise
+    return illust_metadata

--- a/src/crud/illust_metadata_list.py
+++ b/src/crud/illust_metadata_list.py
@@ -1,0 +1,20 @@
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from src.model.illust_metadata import IllustMetadataTable
+
+
+# 全てのレコードのID,イラスト名,ジャンル,イラスト画像を取得
+def get_all_illust_metadata_basic_info(db: Session):
+    try:
+        illust_metadata_basic_info = db.query(
+            IllustMetadataTable.id, 
+            IllustMetadataTable.name, 
+            IllustMetadataTable.genre, 
+            IllustMetadataTable.original_image
+        ).all()
+        if illust_metadata_basic_info is None:
+            raise HTTPException(status_code=404, detail=f"Item not found")
+    except:
+        raise
+    return illust_metadata_basic_info

--- a/src/enum/genre_enum.py
+++ b/src/enum/genre_enum.py
@@ -1,10 +1,10 @@
 from enum import Enum
 
 class GenreEnum(str, Enum):
-    Vehicle = "乗り物"
-    Weather_Season = "天気・季節"
-    Animal = "生き物"
-    Prefectures = "都道府県"
-    Sports = "スポーツ"
-    Symbols = "記号"
-    Other = "その他"
+    Vehicle = '乗り物'
+    Weather_Season = '天気・季節'
+    Animal = '生き物'
+    Prefectures = '都道府県'
+    Sports = 'スポーツ'
+    Symbols = '記号'
+    Other = 'その他'

--- a/src/enum/genre_enum.py
+++ b/src/enum/genre_enum.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 class GenreEnum(str, Enum):
-    Vehicle = "のりもの"
+    Vehicle = "乗り物"
     Weather_Season = "天気・季節"
     Animal = "生き物"
     Prefectures = "都道府県"

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,7 @@ import logging
 import uvicorn
 from fastapi import FastAPI
 
-from src.api import record, records, routing, test, user
+from src.api import illust_metadata, illust_metadata_list, record, records, routing, test, user
 
 app = FastAPI()
 
@@ -23,6 +23,8 @@ app.include_router(user.router, prefix="/users", tags=["User"])
 app.include_router(record.router, prefix="/record", tags=["Record"])
 app.include_router(records.router, prefix="/records", tags=["Records"])
 app.include_router(routing.router, prefix="/routing", tags=["Routing"])
+app.include_router(illust_metadata.router, prefix="/illust_metadata", tags=["IllustMetadata"])
+app.include_router(illust_metadata_list.router, prefix="/illust_metadata_list", tags=["IllustMetadataList"])
 
 
 if __name__ == "__main__":

--- a/src/schema/illust_metadata.py
+++ b/src/schema/illust_metadata.py
@@ -1,14 +1,8 @@
 from pydantic import BaseModel, Field
 from uuid import UUID
-from typing import List, Dict, Any
+from typing import List
 from src.enum.genre_enum import GenreEnum
 
-
-
-class ContourPoint(BaseModel):
-    index: int
-    latitude: float
-    longitude: float
 
 
 class IllustMetadataBase(BaseModel):
@@ -17,15 +11,15 @@ class IllustMetadataBase(BaseModel):
     genre: GenreEnum = Field(examples=["乗り物"], description="Illustration Genre")
     original_image: str = Field(max_length=255, examples=["https://www.example.com/image.png"], description="Illustration original Image URL")
     badge_image: str = Field(max_length=255, examples=["https://www.example.com/image.png"], description="Illustration badge Image URL")
-    contour_points: List[ContourPoint] = Field(description="List of contour points")
+    contour_points: List[dict] = Field(description="List of contour points")
 
 
 class IllustMetadataUpdate(BaseModel):
     name: str = Field(max_length=20, examples=["サンプル イラスト"], description="Illustration Name")
     genre: GenreEnum = Field(examples=["乗り物"], description="Illustration Genre")
-    original_image: str = Field(max_length=255, examples=["https://www.example.com/image.png"], description="Illustration Image URL")
+    original_image: str = Field(max_length=255, examples=["https://www.example.com/image.png"], description="Illustration original Image URL")
     badge_image: str = Field(max_length=255, examples=["https://www.example.com/image.png"], description="Illustration badge Image URL")
-    contour_points: List[ContourPoint] = Field(description="contour points")
+    contour_points: List[dict] = Field(description="List of contour points")
 
 
 class IllustMetadataCreate(IllustMetadataBase):
@@ -34,6 +28,34 @@ class IllustMetadataCreate(IllustMetadataBase):
 
 class IllustMetadataResponse(IllustMetadataBase):
     pass
+
+    class Config:
+        orm_mode = True
+
+
+class IllustMetadataContourResponse(BaseModel):
+    id: UUID = Field(examples=["5c95a0b1-5785-438b-92b6-e3db0984459c"], description="Illustration Metadata ID")
+    contour_points: List[dict] = Field(description="List of contour points")
+    
+    class Config:
+        orm_mode = True
+
+
+class IllustMetadataBadgeImageResponse(BaseModel):
+    id: UUID = Field(examples=["5c95a0b1-5785-438b-92b6-e3db0984459c"], description="Illustration Metadata ID")
+    name: str = Field(max_length=20, examples=["サンプル イラスト"], description="Illustration Name")
+    badge_image: str = Field(max_length=255, examples=["https://www.example.com/image.png"], description="Illustration badge Image URL")
+
+    class Config:
+        orm_mode = True
+
+
+class IllustMetadataBasicInfoResponse(BaseModel):
+    id: UUID = Field(examples=["5c95a0b1-5785-438b-92b6-e3db0984459c"], description="Illustration Metadata ID")
+    name: str = Field(max_length=20, examples=["サンプル イラスト"], description="Illustration Name")
+    genre: GenreEnum = Field(examples=["乗り物"], description="Illustration Genre")
+    original_image: str = Field(max_length=255, examples=["https://www.example.com/image.png"], description="Illustration original Image URL")
+
 
     class Config:
         orm_mode = True

--- a/src/schema/illust_metadata.py
+++ b/src/schema/illust_metadata.py
@@ -1,0 +1,39 @@
+from pydantic import BaseModel, Field
+from uuid import UUID
+from typing import List, Dict, Any
+from src.enum.genre_enum import GenreEnum
+
+
+
+class ContourPoint(BaseModel):
+    index: int
+    latitude: float
+    longitude: float
+
+
+class IllustMetadataBase(BaseModel):
+    id: UUID = Field(examples=["5c95a0b1-5785-438b-92b6-e3db0984459c"], description="Illustration Metadata ID")
+    name: str = Field(max_length=20, examples=["サンプル イラスト"], description="Illustration Name")
+    genre: GenreEnum = Field(examples=["乗り物"], description="Illustration Genre")
+    original_image: str = Field(max_length=255, examples=["https://www.example.com/image.png"], description="Illustration original Image URL")
+    badge_image: str = Field(max_length=255, examples=["https://www.example.com/image.png"], description="Illustration badge Image URL")
+    contour_points: List[ContourPoint] = Field(description="List of contour points")
+
+
+class IllustMetadataUpdate(BaseModel):
+    name: str = Field(max_length=20, examples=["サンプル イラスト"], description="Illustration Name")
+    genre: GenreEnum = Field(examples=["乗り物"], description="Illustration Genre")
+    original_image: str = Field(max_length=255, examples=["https://www.example.com/image.png"], description="Illustration Image URL")
+    badge_image: str = Field(max_length=255, examples=["https://www.example.com/image.png"], description="Illustration badge Image URL")
+    contour_points: List[ContourPoint] = Field(description="contour points")
+
+
+class IllustMetadataCreate(IllustMetadataBase):
+    pass
+
+
+class IllustMetadataResponse(IllustMetadataBase):
+    pass
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
- illust metada tableのcrudを作成
- api/illust_metadataの中身
    - get_illust_metadata_contour(id)・・・IDから輪郭の相対座標を取得
    - get_illust_metadata_badge_image・・・IDからバッジ画像を取得
- api/illust_metadata_listの中身
    - get_all_illust_metadata_basic_info()・・・全てのレコードのID,イラスト名,ジャンル,イラスト画像を取得